### PR TITLE
Terminate the template_manager when catching a signal

### DIFF
--- a/bin/consul-templaterb
+++ b/bin/consul-templaterb
@@ -239,6 +239,7 @@ end
 %w[INT PIPE TERM].each do |sig|
   Signal.trap(sig) do
     STDERR.puts "[KILL] received #{sig}, stopping myself"
+    template_manager.terminate
     kill_program
   end
 end


### PR DESCRIPTION
So connections aren't all logging that they're dying, probably saner for client connections too