### PR TITLE
Remove Criteo specifics

### DIFF
--- a/lib/consul/async/utilities.rb
+++ b/lib/consul/async/utilities.rb
@@ -7,12 +7,18 @@ module Consul
       def self.bytes_to_h(bytes)
         if bytes < 1024
           "#{bytes} b"
-        elsif bytes < 1_048_576
-          "#{(bytes / 1024).round(2)} Kb"
-        elsif bytes < 1_073_741_824
-          "#{(bytes / 1_048_576.0).round(2)} Mb"
         else
-          "#{(bytes / 1_073_741_824.0).round(2)} Gb"
+          if bytes < 1_048_576
+            bytes_h = bytes / 1024.0
+            unit_prefix = 'K'
+          elsif bytes < 1_073_741_824
+            bytes_h = bytes / 1_048_576.0
+            unit_prefix = 'M'
+          else
+            bytes_h = bytes / 1_073_741_824.0
+            unit_prefix = 'G'
+          end
+          "#{bytes_h.round(2)} #{unit_prefix}b"
         end
       end
 

--- a/samples/criteo/haproxy.cfg.erb
+++ b/samples/criteo/haproxy.cfg.erb
@@ -116,25 +116,8 @@ listen stats
 
 # ==== Managed by consul-templaterb ====
 
-frontend fe_main # HTTP(S) Service
+frontend fe_main
     bind *:80 name http
-
-    # Monitoring
-    monitor-uri /delivery/monitor/mesos-haproxy/lb-check
-    errorfile 200 /etc/haproxy/200-criteo-ok.txt
-
-    # Adding a header indicating client side is using HTTPS
-    acl http  ssl_fc,not
-    acl https ssl_fc
-    http-request set-header X-Forwarded-Protocol https if https
-
-    # Disable CONNECT globally (identified as vulnerability by audit tools such as Qualys)
-    acl ::disabled_http_methods method CONNECT
-    http-request block if ::disabled_http_methods
-
-    # Consul-agent ACL
-    acl consul-agent-http-acl hdr_dom(host) -i  consul-agent-http.lb-ty5.crto.in consul-agent-http.lb-ty5.central.criteo.prod
-    use_backend bestatic_consul-agent-http if consul-agent-http-acl
 
     # ACLs, HTTP Host header based, following the pattern <consul_app_name>.<fqdn_suffix>
 <% backends.each_pair do |service_name, nodes|
@@ -144,10 +127,6 @@ frontend fe_main # HTTP(S) Service
 <% end %>
 
 # Backends
-backend bestatic_consul-agent-http
-    http-request deny if !METH_GET # Deny writes
-    server srv0 127.0.0.1:8500
-
 <% backends.each_pair do |service_name, nodes|
 %>
 backend be_<%= service_name %>

--- a/spec/consul/async/async_mock.rb
+++ b/spec/consul/async/async_mock.rb
@@ -48,7 +48,7 @@ module Consul
          v1/agent/self
          v1/catalog/datacenters
          v1/catalog/nodes
-         v1/catalog/node/consul02-par.central.criteo.preprod
+         v1/catalog/node/consul02.prod
          v1/catalog/node/7a985997-3925-4f18-8613-637c81bd750b
          v1/catalog/services
          v1/health/checks/consul

--- a/spec/consul/async/resources/consul/v1/catalog/node/7a985997-3925-4f18-8613-637c81bd750b.json
+++ b/spec/consul/async/resources/consul/v1/catalog/node/7a985997-3925-4f18-8613-637c81bd750b.json
@@ -1,6 +1,6 @@
 {
   "ID": "7a985997-3925-4f18-8613-637c81bd750b",
-  "Node": "consul02-par.central.criteo.preprod",
+  "Node": "consul02.prod",
   "Address": "10.251.1.96",
   "Datacenter": "par",
   "TaggedAddresses": {

--- a/spec/consul/async/resources/consul/v1/catalog/node/consul02.prod.json
+++ b/spec/consul/async/resources/consul/v1/catalog/node/consul02.prod.json
@@ -1,6 +1,6 @@
 {
   "ID": "7a985997-3925-4f18-8613-637c81bd750b",
-  "Node": "consul02-par.central.criteo.preprod",
+  "Node": "consul02.prod",
   "Address": "10.251.1.96",
   "Datacenter": "par",
   "TaggedAddresses": {

--- a/spec/consul/async/resources/consul/v1/catalog/nodes.json
+++ b/spec/consul/async/resources/consul/v1/catalog/nodes.json
@@ -1,7 +1,7 @@
 [
   {
     "ID": "",
-    "Node": "consul01-par.central.criteo.preprod",
+    "Node": "consul01.prod",
     "Address": "10.251.1.98",
     "Datacenter": "",
     "TaggedAddresses": {
@@ -14,7 +14,7 @@
   },
   {
     "ID": "7a985997-3925-4f18-8613-637c81bd750b",
-    "Node": "consul02-par.central.criteo.preprod",
+    "Node": "consul02.prod",
     "Address": "10.251.1.96",
     "Datacenter": "par",
     "TaggedAddresses": {
@@ -30,7 +30,7 @@
   },
   {
     "ID": "830c08a0-34d2-ed54-57ff-a30d9b1b6e35",
-    "Node": "consul03-par.central.criteo.preprod",
+    "Node": "consul03.prod",
     "Address": "10.251.1.97",
     "Datacenter": "par",
     "TaggedAddresses": {
@@ -46,7 +46,7 @@
   },
   {
     "ID": "830c08a0-34d2-ed54-0000-a30d9b1b6e35",
-    "Node": "consul04-par.central.criteo.preprod",
+    "Node": "consul04.prod",
     "Address": "10.251.1.99",
     "Datacenter": "par",
     "TaggedAddresses": {

--- a/spec/consul/async/resources/consul/v1/health/checks/consul.json
+++ b/spec/consul/async/resources/consul/v1/health/checks/consul.json
@@ -1,6 +1,6 @@
 [
     {
-        "Node": "consul04-par.central.criteo.preprod",
+        "Node": "consul04.prod",
         "CheckID": "consul-exta-check",
         "Name": "marathon_http_check_0",
         "Status": "passing",

--- a/spec/consul/async/resources/consul/v1/health/service/consul.json
+++ b/spec/consul/async/resources/consul/v1/health/service/consul.json
@@ -2,7 +2,7 @@
   {
     "Node": {
       "ID": "",
-      "Node": "consul01-par.central.criteo.preprod",
+      "Node": "consul01.prod",
       "Address": "10.251.1.98",
       "Datacenter": "",
       "TaggedAddresses": {
@@ -25,7 +25,7 @@
     },
     "Checks": [
       {
-        "Node": "consul01-par.central.criteo.preprod",
+        "Node": "consul01.prod",
         "CheckID": "serfHealth",
         "Name": "Serf Health Status",
         "Status": "passing",
@@ -42,7 +42,7 @@
   {
     "Node": {
       "ID": "7a985997-3925-4f18-8613-637c81bd750b",
-      "Node": "consul02-par.central.criteo.preprod",
+      "Node": "consul02.prod",
       "Address": "10.251.1.96",
       "Datacenter": "par",
       "TaggedAddresses": {
@@ -68,7 +68,7 @@
     },
     "Checks": [
       {
-        "Node": "consul02-par.central.criteo.preprod",
+        "Node": "consul02.prod",
         "CheckID": "serfHealth",
         "Name": "Serf Health Status",
         "Status": "passing",
@@ -85,7 +85,7 @@
   {
     "Node": {
       "ID": "830c08a0-34d2-ed54-57ff-a30d9b1b6e35",
-      "Node": "consul03-par.central.criteo.preprod",
+      "Node": "consul03.prod",
       "Address": "10.251.1.97",
       "Datacenter": "par",
       "TaggedAddresses": {
@@ -111,7 +111,7 @@
     },
     "Checks": [
       {
-        "Node": "consul03-par.central.criteo.preprod",
+        "Node": "consul03.prod",
         "CheckID": "serfHealth",
         "Name": "Serf Health Status",
         "Status": "passing",
@@ -128,7 +128,7 @@
   {
     "Node": {
       "ID": "830c08a0-34d2-ed54-0000-a30d9b1b6e35",
-      "Node": "consul04-par.central.criteo.preprod",
+      "Node": "consul04.prod",
       "Address": "10.251.1.99",
       "Datacenter": "par",
       "TaggedAddresses": {
@@ -154,7 +154,7 @@
     },
     "Checks": [
       {
-        "Node": "consul03-par.central.criteo.preprod",
+        "Node": "consul03.prod",
         "CheckID": "serfHealth",
         "Name": "Serf Health Status",
         "Status": "critical",

--- a/spec/consul/async/resources/samples/haproxy.cfg
+++ b/spec/consul/async/resources/samples/haproxy.cfg
@@ -19,10 +19,10 @@ defaults
 backend backend_http__consul
   mode http
   balance leastconn
-  server consul01-par.central.criteo.preprod_8300 5.6.7.8:8300 weight 100
-  server consul02-par.central.criteo.preprod_8300 10.251.1.96:8300 weight 100
-  server consul03-par.central.criteo.preprod_8300 10.251.1.97:8300 weight 100
-  server consul04-par.central.criteo.preprod_8300 10.251.1.99:8300 disabled weight 100
+  server consul01.prod_8300 5.6.7.8:8300 weight 100
+  server consul02.prod_8300 10.251.1.96:8300 weight 100
+  server consul03.prod_8300 10.251.1.97:8300 weight 100
+  server consul04.prod_8300 10.251.1.99:8300 disabled weight 100
 
 frontend fontend_http
    mode http

--- a/spec/consul/async/resources/templates/unit_checks_for_service.txt.expected
+++ b/spec/consul/async/resources/templates/unit_checks_for_service.txt.expected
@@ -2,7 +2,7 @@ Check Consul
 -------
 CheckID: consul-exta-check
 Name: marathon_http_check_0
-Node: consul04-par.central.criteo.preprod<
+Node: consul04.prod<
 Notes: Simple HTTP Check
 Output: HTTP GET http://localhost:8500/health: 200 OK Output: OK
 Status: passing

--- a/spec/consul/async/resources/templates/unit_consul.txt.expected
+++ b/spec/consul/async/resources/templates/unit_consul.txt.expected
@@ -1,5 +1,5 @@
 Service Consul
-consul01-par.central.criteo.preprod:8300
-consul02-par.central.criteo.preprod:8300
-consul03-par.central.criteo.preprod:8300
-consul04-par.central.criteo.preprod:8300
+consul01.prod:8300
+consul02.prod:8300
+consul03.prod:8300
+consul04.prod:8300

--- a/spec/consul/async/resources/templates/unit_nodes.erb
+++ b/spec/consul/async/resources/templates/unit_nodes.erb
@@ -5,5 +5,5 @@ Nodes
 <%
   end
 %>
-Node: <%= node('consul02-par.central.criteo.preprod')['Node'] %>
+Node: <%= node('consul02.prod')['Node'] %>
 ID: <%= node('7a985997-3925-4f18-8613-637c81bd750b')['ID'] %>

--- a/spec/consul/async/resources/templates/unit_nodes.txt.expected
+++ b/spec/consul/async/resources/templates/unit_nodes.txt.expected
@@ -1,8 +1,8 @@
 Nodes
-consul01-par.central.criteo.preprod
-consul02-par.central.criteo.preprod
-consul03-par.central.criteo.preprod
-consul04-par.central.criteo.preprod
+consul01.prod
+consul02.prod
+consul03.prod
+consul04.prod
 
-Node: consul02-par.central.criteo.preprod
+Node: consul02.prod
 ID: 7a985997-3925-4f18-8613-637c81bd750b

--- a/spec/consul/async/resources/templates/unit_service.txt.expected
+++ b/spec/consul/async/resources/templates/unit_service.txt.expected
@@ -1,8 +1,8 @@
 Service Consul
-5.6.7.8:8300 (consul01-par.central.criteo.preprod)
-10.251.1.96:8300 (consul02-par.central.criteo.preprod)
-10.251.1.97:8300 (consul03-par.central.criteo.preprod)
-10.251.1.99:8300 (consul04-par.central.criteo.preprod)
+5.6.7.8:8300 (consul01.prod)
+10.251.1.96:8300 (consul02.prod)
+10.251.1.97:8300 (consul03.prod)
+10.251.1.99:8300 (consul04.prod)
 ---
 Service Consul filter UI
-consul04-par.central.criteo.preprod:8300
+consul04.prod:8300


### PR DESCRIPTION
It can be tricky to understand what are the Criteo specifics from the specs and even the templates.
Removing all the internal naming conventions.

Also first had to fix something related to `ConsulAsyncUtilities.bytes_to_h` to make tests pass.