### PR TITLE
Add a last_modified stats object to track endpoint modifications

### DIFF
--- a/TemplateAPI.md
+++ b/TemplateAPI.md
@@ -30,7 +30,7 @@ On each object, you can access the `.endpoint` object that includes several info
 
 * `myresult.endpoint.x_consul_index` return the current index on blocking query
 * `myresult.endpoint.stats` a object with interresting fields: `bytes_per_sec`,
-  `bytes_per_sec_human`, `successes`, `errors`, `body_bytes`. All stats details
+  `bytes_per_sec_human`, `successes`, `errors`, `body_bytes`, `last_modified`. All stats details
   are available in the file [lib/consul/async/stats.rb](lib/consul/async/stats.rb).
 
 Using those statistics might be useful to trigger alerts very easily when something

--- a/lib/consul/async/stats.rb
+++ b/lib/consul/async/stats.rb
@@ -3,7 +3,7 @@ require 'consul/async/utilities'
 module Consul
   module Async
     class EndPointStats
-      attr_reader :successes, :errors, :start, :body_bytes, :last_error, :last_success, :changes, :network_bytes
+      attr_reader :successes, :errors, :start, :body_bytes, :last_error, :last_success, :last_modified, :changes, :network_bytes
 
       def initialize
         @start = Time.now.utc
@@ -14,6 +14,7 @@ module Consul
         @network_bytes = 0
         @last_error = @start
         @last_success = @start
+        @last_modified = @start
       end
 
       def on_response(res)
@@ -21,6 +22,7 @@ module Consul
         @successes += 1
         @body_bytes += res.http.response.bytesize
         @changes += 1 if res.modified?
+        @last_modified = @last_success if res.modified?
         @network_bytes += res.http.response_header['Content-Length'].to_i
       end
 


### PR DESCRIPTION
This will let users track last modification for their endpoint independently
TODO: Add something that could track all endpoints in a single file