### PR TITLE
Support any request method for remote_resource.as_json

### DIFF
--- a/TemplateAPI.md
+++ b/TemplateAPI.md
@@ -439,10 +439,16 @@ secret('secret/foo', [force_ttl: intInSecond])
 ### as_json(url, default_value, [refresh_delay_secs: intInSecond])
 
 Fetch json data from any url. This allows to create templates with consul/vault data mixed in with data coming from other services/api.
-Polling interval can be controlled with refresh_delay_secs.
+Polling interval can be controlled with `refresh_delay_secs` option.
+Request method (`GET`, `POST`, ...) can be controlled with `request_method` option.
 
 ```erb
 remote_resource.as_json('http://my-api.dev/fridge/list.json', [])
+```
+
+Example with post (json_body will be applied `to_json` automatically):
+```erb
+remote_resource.as_json('http://my-api.dev/fridge', [], request_method: :post, json_body: {brand: 'any'})
 ```
 
 Full example: [samples/list_ruby_versions_from_rubygems.txt.erb](samples/list_ruby_versions_from_rubygems.txt.erb)

--- a/lib/consul/async/consul_template.rb
+++ b/lib/consul/async/consul_template.rb
@@ -26,8 +26,8 @@ module Consul
         @endp_manager = endpoints_manager
       end
 
-      def as_json(url, default_value, refresh_delay_secs: 10)
-        conf = JSONConfiguration.new(url: url, min_duration: refresh_delay_secs, retry_on_non_diff: refresh_delay_secs)
+      def as_json(url, default_value, refresh_delay_secs: 10, **opts)
+        conf = JSONConfiguration.new(url: url, min_duration: refresh_delay_secs, retry_on_non_diff: refresh_delay_secs, **opts)
         @endp_manager.create_if_missing(url, {}) do
           if default_value.is_a?(Array)
             ConsulTemplateJSONArray.new(JSONEndpoint.new(conf, url, default_value))


### PR DESCRIPTION
- support post and other request methods
- accept any 2xx result (instead of just 200). This is a semi-breaking
  change.
- accept body passed for non GET requests

Change-Id: I8cf6b61421ba5290f928478a808806c4bac53adb