### PR TITLE
Correctly schedule retry for timeouts on vault

### DIFF
--- a/lib/consul/async/vault_endpoint.rb
+++ b/lib/consul/async/vault_endpoint.rb
@@ -199,7 +199,7 @@ module Consul
         http_result = VaultHttpResponse.new(http, default_value)
         EventMachine.add_timer(retry_in) do
           yield
-          queue.push
+          queue.push(0)
         end
         @e_callbacks.each { |c| c.call(http_result) }
       end


### PR DESCRIPTION
When receiving timeout (or other errors), we need to schedule a retry.
This is done by enqueuing an object on the event machine queue.
Otherwise, we never attempt any retry.

This is easy to reproduce when creating a template using >200 secrets in
vault. For instance on criteo vault:

```
users # <- a list of 30 users
  .sort
  .each do |account|
    private_keys = secret("services/mesos/rsa-keys/private/#{account}")['data']
    private_keys = secret("services/mesos/rsa-keys/public/#{account}")['data']
    consul_token = secret("services/mesos/consul-tokens/#{account}")['data']
    kerberos = secret("services/accounts/svc-#{account}")['data']
end
```

Change-Id: I3744c6c80803499cbf1dc77fc0da324f5815ea8a