### PR TITLE
Add `templates` api to list rendered templates

### DIFF
--- a/TemplateAPI.md
+++ b/TemplateAPI.md
@@ -649,3 +649,26 @@ I am the file template_info.erb included from template include.erb rendered as d
 
 </div>
 </details>
+
+## templates
+
+It returns list of templates evaluated by this instance of consul-templaterb.
+Information returned is an array of elements where elements are `[template_name, template_destination, args]`.
+
+<details><summary>Example</summary>
+<div class="samples">
+
+### Display templates info
+
+```erb
+Here are templates rendered by consul-templaterb:
+<ul>
+<% templates.each do |template, destination, args| %>
+<li>I render <%= template %> with args <%= args.inspect %> and write the result to <%= destination %></li>
+<% end %>
+</ul>
+```
+
+</div>
+</details>
+

--- a/bin/consul-templaterb
+++ b/bin/consul-templaterb
@@ -290,13 +290,14 @@ EM.epoll
 
 consul_conf = Consul::Async::ConsulConfiguration.new(options[:consul])
 vault_conf = Consul::Async::VaultConfiguration.new(options[:vault])
-template_manager = Consul::Async::EndPointsManager.new(consul_conf, vault_conf, options[:erb][:trim_mode])
 
 ARGV.each do |tpl|
   dest = compute_default_output(tpl)
   ::Consul::Async::Debug.puts_info "Using #{dest} output for #{tpl}"
   consul_engine.add_template(tpl, dest)
 end
+
+template_manager = Consul::Async::EndPointsManager.new(consul_conf, vault_conf, consul_engine.templates, options[:erb][:trim_mode])
 
 Signal.trap('USR1', 'IGNORE') unless Gem.win_platform?
 # Ensure to kill child process if any

--- a/lib/consul/async/consul_template.rb
+++ b/lib/consul/async/consul_template.rb
@@ -79,8 +79,8 @@ module Consul
     end
 
     class EndPointsManager
-      attr_reader :consul_conf, :vault_conf, :net_info, :start_time, :coordinate, :remote_resource
-      def initialize(consul_configuration, vault_configuration, trim_mode = nil)
+      attr_reader :consul_conf, :vault_conf, :net_info, :start_time, :coordinate, :remote_resource, :templates
+      def initialize(consul_configuration, vault_configuration, templates, trim_mode = nil)
         @consul_conf = consul_configuration
         @vault_conf = vault_configuration
         @trim_mode = trim_mode
@@ -95,6 +95,7 @@ module Consul
           changes: 0,
           network_bytes: 0
         }
+        @templates = templates
         @context = {
           current_erb_path: nil,
           template_info: {

--- a/lib/consul/async/consul_template_engine.rb
+++ b/lib/consul/async/consul_template_engine.rb
@@ -10,7 +10,7 @@ require 'erb'
 module Consul
   module Async
     class ConsulTemplateEngine
-      attr_reader :template_manager, :hot_reload_failure, :template_frequency, :debug_memory, :result
+      attr_reader :template_manager, :hot_reload_failure, :template_frequency, :debug_memory, :result, :templates
       attr_writer :hot_reload_failure, :template_frequency, :debug_memory
       def initialize
         @templates = []

--- a/samples/all_templates.erb
+++ b/samples/all_templates.erb
@@ -1,0 +1,3 @@
+<% templates.each do |erb_file, output_file, args| %>
+  <%= erb_file %> will be rendered as <%= output_file %>
+<% end %>

--- a/spec/consul/async/consul_template_engine_spec.rb
+++ b/spec/consul/async/consul_template_engine_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Consul::Async::ConsulTemplateEngine do
   it 'Renders properly ha_proxy.cfg.erb' do
     mock_consul
     EM.run_block do
-      template_manager = Consul::Async::EndPointsManager.new(@consul_conf, @vault_conf)
       template_file = find_absolute_path('../../../../samples/ha_proxy.cfg.erb')
       output_file = 'out.txt'
+      template_manager = Consul::Async::EndPointsManager.new(@consul_conf, @vault_conf, [[template_file, output_file, {}]])
       @renderer = Consul::Async::ConsulTemplateRender.new(template_manager, template_file, output_file)
       @renderer.run
     end
@@ -36,9 +36,9 @@ RSpec.describe Consul::Async::ConsulTemplateEngine do
       mock_vault
       mock_json
       EM.run_block do
-        template_manager = Consul::Async::EndPointsManager.new(@consul_conf, @vault_conf)
         template_file = erb
         output_file = 'out.txt'
+        template_manager = Consul::Async::EndPointsManager.new(@consul_conf, @vault_conf, [[template_file, output_file, {}]])
         @renderer = Consul::Async::ConsulTemplateRender.new(template_manager, template_file, output_file)
       end
       # For multi-pass templates, we wait for up to 3 iterations

--- a/spec/consul/async/consul_template_template_render_spec.rb
+++ b/spec/consul/async/consul_template_template_render_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Consul::Async::ConsulTemplateRender do
       mock_vault
       mock_json
       EM.run_block do
-        template_manager = Consul::Async::EndPointsManager.new(@consul_conf, @vault_conf)
         template_file = erb
         @template_value = File.read(template_file)
         output_file = erb.gsub(/\.erb$/, '.txt')
+        template_manager = Consul::Async::EndPointsManager.new(@consul_conf, @vault_conf, [[template_file, output_file, {}]])
         @renderer = Consul::Async::ConsulTemplateRender.new(template_manager, template_file, output_file)
         @renderer.run
       end


### PR DESCRIPTION
This commit introduces `templates` in the api available to templates.
It allows to access list of templates rendered by consul-templaterb.

The interest of this would be to write automatically index.html listing
all generated templates (for instance)

Implements #52

Change-Id: Ia2f88889bdf457874b7e28b1a85d728eb07e2fdc