### PR TITLE
Support TLS client options for Consul and Vault

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ Layout/LineLength:
   Max: 175
 
 Metrics/AbcSize:
-  Max: 82
+  Max: 87
 
 Metrics/BlockLength:
   Max: 160
@@ -19,16 +19,16 @@ Metrics/ClassLength:
   Max: 275
 
 Metrics/CyclomaticComplexity:
-  Max: 20
+  Max: 21
 
 Metrics/MethodLength:
-  Max: 65
+  Max: 68
 
 Metrics/ParameterLists:
-  Max: 14
+  Max: 18
 
 Metrics/PerceivedComplexity:
-  Max: 23
+  Max: 24
 
 # We use `dc` as a parameter in many methods
 Naming/MethodParameterName:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
   Max: 87
 
 Metrics/BlockLength:
-  Max: 160
+  Max: 182
 
 Metrics/BlockNesting:
   Max: 4

--- a/bin/consul-templaterb
+++ b/bin/consul-templaterb
@@ -28,9 +28,9 @@ options = {
     },
     base_url: ENV['VAULT_ADDR'] || 'http://localhost:8200',
     token: ENV['VAULT_TOKEN'] || nil,
-    tls_client_cert: ENV['VAULT_CLIENT_CERT'] || nil,
-    tls_client_key: ENV['VAULT_CLIENT_KEY'] || nil,
-    tls_cacert: ENV['VAULT_CACERT'] || nil,
+    tls_cert_chain: ENV['VAULT_CLIENT_CERT'] || nil,
+    tls_private_key: ENV['VAULT_CLIENT_KEY'] || nil,
+    tls_verify_peer: true,
     max_consecutive_errors_on_endpoint: 10, # Stop program after n consecutive failures on same endpoint
     fail_fast_errors: nil,                  # fail fast the program if endpoint was never success
     token_renew: true,
@@ -51,9 +51,9 @@ options = {
     },
     base_url: ENV['CONSUL_HTTP_ADDR'] || 'http://localhost:8500',
     token: ENV['CONSUL_HTTP_TOKEN'] || nil,
-    tls_client_cert: ENV['CONSUL_CLIENT_CERT'] || nil,
-    tls_client_key: ENV['CONSUL_CLIENT_KEY'] || nil,
-    tls_cacert: ENV['CONSUL_CACERT'] || nil,
+    tls_cert_chain: ENV['CONSUL_CLIENT_CERT'] || nil,
+    tls_private_key: ENV['CONSUL_CLIENT_KEY'] || nil,
+    tls_verify_peer: true,
     max_consecutive_errors_on_endpoint: 10, # Stop program after n consecutive failures on same endpoint
     fail_fast_errors: nil,                  # fail fast the program if endpoint was never success
     retry_duration: 10,      # On error, retry after n seconds
@@ -128,6 +128,18 @@ optparse = OptionParser.new do |opts|
     options[:consul][:base_url] = consul_url
   end
 
+  opts.on('--consul-cert-chain=<path/to/cert_chain>', String, 'Path to Consul TLS client certificate chain to use') do |consul_client_cert|
+    options[:consul][:tls_cert_chain] = consul_client_cert
+  end
+
+  opts.on('--consul-private-key=<path/to/private_key>', String, 'Path to Consul TLS client private key to use') do |consul_client_key|
+    options[:consul][:tls_private_key] = consul_client_key
+  end
+
+  opts.on('--skip-consul-verify-tls', 'Skip verifying Consul TLS via certificate authority (DANGEROUS)') do
+    options[:consul][:tls_verify_peer] = false
+  end
+
   opts.on('-l', '--log-level=<log_level>', String, "Log level, default=info, any of #{::Consul::Async::Debug.levels.join('|')}") do |log_level|
     ::Consul::Async::Debug.level = log_level
   end
@@ -138,6 +150,18 @@ optparse = OptionParser.new do |opts|
 
   opts.on('-V', '--vault-addr=<address>', String, 'Address of Vault, eg: http://localhost:8200') do |vault_url|
     options[:vault][:base_url] = vault_url
+  end
+
+  opts.on('--vault-cert-chain=<path/to/cert_chain>', String, 'Path to Vault TLS client certificate chain to use') do |vault_client_cert|
+    options[:vault][:tls_cert_chain] = vault_client_cert
+  end
+
+  opts.on('--vault-private-key=<path/to/private_key>', String, 'Path to Vault TLS client private key to use') do |vault_client_key|
+    options[:vault][:tls_private_key] = vault_client_key
+  end
+
+  opts.on('--skip-vault-verify-tls', 'Skip verifying Vault TLS via certificate authority (DANGEROUS)') do
+    options[:vault][:tls_verify_peer] = false
   end
 
   opts.on('-T', '--vault-token=<token>', String, 'Token used to authenticate against vault.') do |vault_token|

--- a/bin/consul-templaterb
+++ b/bin/consul-templaterb
@@ -28,6 +28,9 @@ options = {
     },
     base_url: ENV['VAULT_ADDR'] || 'http://localhost:8200',
     token: ENV['VAULT_TOKEN'] || nil,
+    tls_client_cert: ENV['VAULT_CLIENT_CERT'] || nil,
+    tls_client_key: ENV['VAULT_CLIENT_KEY'] || nil,
+    tls_cacert: ENV['VAULT_CACERT'] || nil,
     max_consecutive_errors_on_endpoint: 10, # Stop program after n consecutive failures on same endpoint
     fail_fast_errors: nil,                  # fail fast the program if endpoint was never success
     token_renew: true,
@@ -48,6 +51,9 @@ options = {
     },
     base_url: ENV['CONSUL_HTTP_ADDR'] || 'http://localhost:8500',
     token: ENV['CONSUL_HTTP_TOKEN'] || nil,
+    tls_client_cert: ENV['CONSUL_CLIENT_CERT'] || nil,
+    tls_client_key: ENV['CONSUL_CLIENT_KEY'] || nil,
+    tls_cacert: ENV['CONSUL_CACERT'] || nil,
     max_consecutive_errors_on_endpoint: 10, # Stop program after n consecutive failures on same endpoint
     fail_fast_errors: nil,                  # fail fast the program if endpoint was never success
     retry_duration: 10,      # On error, retry after n seconds

--- a/lib/consul/async/consul_endpoint.rb
+++ b/lib/consul/async/consul_endpoint.rb
@@ -9,7 +9,7 @@ module Consul
     class ConsulConfiguration
       attr_reader :base_url, :token, :retry_duration, :min_duration, :wait_duration, :max_retry_duration, :retry_on_non_diff,
                   :missing_index_retry_time_on_diff, :missing_index_retry_time_on_unchanged, :debug, :enable_gzip_compression,
-                  :fail_fast_errors, :max_consecutive_errors_on_endpoint, :tls_client_cert, :tls_client_key, :tls_cacert
+                  :fail_fast_errors, :max_consecutive_errors_on_endpoint, :tls_cert_chain, :tls_private_key, :tls_verify_peer
       def initialize(base_url: 'http://localhost:8500',
                      debug: { network: false },
                      token: nil,
@@ -24,9 +24,9 @@ module Consul
                      paths: {},
                      max_consecutive_errors_on_endpoint: 10,
                      fail_fast_errors: 1,
-                     tls_client_cert: nil,
-                     tls_client_key: nil,
-                     tls_cacert: nil)
+                     tls_cert_chain: nil,
+                     tls_private_key: nil,
+                     tls_verify_peer: true)
         @base_url = base_url
         @token = token
         @debug = debug
@@ -41,9 +41,9 @@ module Consul
         @paths = paths
         @max_consecutive_errors_on_endpoint = max_consecutive_errors_on_endpoint
         @fail_fast_errors = fail_fast_errors
-        @tls_client_cert = tls_client_cert
-        @tls_client_key = tls_client_key
-        @tls_cacert = tls_cacert
+        @tls_cert_chain = tls_cert_chain
+        @tls_private_key = tls_private_key
+        @tls_verify_peer = tls_verify_peer
       end
 
       def ch(path, symbol)
@@ -78,9 +78,9 @@ module Consul
                                 paths: @paths,
                                 max_consecutive_errors_on_endpoint: @max_consecutive_errors_on_endpoint,
                                 fail_fast_errors: @fail_fast_errors,
-                                tls_client_cert: ch(path, :tls_client_cert),
-                                tls_client_key: ch(path, :tls_client_key),
-                                tls_cacert: ch(path, :tls_cacert))
+                                tls_cert_chain: ch(path, :tls_cert_chain),
+                                tls_private_key: ch(path, :tls_private_key),
+                                tls_verify_peer: ch(path, :tls_verify_peer))
       end
     end
 
@@ -242,11 +242,11 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: conf.wait_duration + 1 + (conf.wait_duration / 16) # default connection inactivity (post-setup) timeout
         }
-        unless conf.tls_client_cert.nil?
+        unless conf.tls_cert_chain.nil?
           options[:tls] = {
-            cert_chain_file: conf.tls_client_cert,
-            private_key_file: conf.tls_client_key,
-            verify_peer: false # TODO: use the tls_cacert in the cert_chain_file and verify
+            cert_chain_file: conf.tls_cert_chain,
+            private_key_file: conf.tls_private_key,
+            verify_peer: conf.tls_verify_peer
           }
         end
         connection = {

--- a/lib/consul/async/consul_endpoint.rb
+++ b/lib/consul/async/consul_endpoint.rb
@@ -80,8 +80,7 @@ module Consul
                                 fail_fast_errors: @fail_fast_errors,
                                 tls_client_cert: ch(path, :tls_client_cert),
                                 tls_client_key: ch(path, :tls_client_key),
-                                tls_cacert: ch(path, :tls_cacert)
-                                )
+                                tls_cacert: ch(path, :tls_cacert))
       end
     end
 
@@ -243,7 +242,7 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: conf.wait_duration + 1 + (conf.wait_duration / 16) # default connection inactivity (post-setup) timeout
         }
-        if !conf.tls_client_cert.nil?
+        unless conf.tls_client_cert.nil?
           options[:tls] = {
             cert_chain_file: conf.tls_client_cert,
             private_key_file: conf.tls_client_key,

--- a/lib/consul/async/consul_endpoint.rb
+++ b/lib/consul/async/consul_endpoint.rb
@@ -9,7 +9,7 @@ module Consul
     class ConsulConfiguration
       attr_reader :base_url, :token, :retry_duration, :min_duration, :wait_duration, :max_retry_duration, :retry_on_non_diff,
                   :missing_index_retry_time_on_diff, :missing_index_retry_time_on_unchanged, :debug, :enable_gzip_compression,
-                  :fail_fast_errors, :max_consecutive_errors_on_endpoint
+                  :fail_fast_errors, :max_consecutive_errors_on_endpoint, :tls_client_cert, :tls_client_key, :tls_cacert
       def initialize(base_url: 'http://localhost:8500',
                      debug: { network: false },
                      token: nil,
@@ -23,7 +23,10 @@ module Consul
                      enable_gzip_compression: true,
                      paths: {},
                      max_consecutive_errors_on_endpoint: 10,
-                     fail_fast_errors: 1)
+                     fail_fast_errors: 1,
+                     tls_client_cert: nil,
+                     tls_client_key: nil,
+                     tls_cacert: nil)
         @base_url = base_url
         @token = token
         @debug = debug
@@ -38,6 +41,9 @@ module Consul
         @paths = paths
         @max_consecutive_errors_on_endpoint = max_consecutive_errors_on_endpoint
         @fail_fast_errors = fail_fast_errors
+        @tls_client_cert = tls_client_cert
+        @tls_client_key = tls_client_key
+        @tls_cacert = tls_cacert
       end
 
       def ch(path, symbol)
@@ -71,7 +77,11 @@ module Consul
                                 enable_gzip_compression: enable_gzip_compression,
                                 paths: @paths,
                                 max_consecutive_errors_on_endpoint: @max_consecutive_errors_on_endpoint,
-                                fail_fast_errors: @fail_fast_errors)
+                                fail_fast_errors: @fail_fast_errors,
+                                tls_client_cert: ch(path, :tls_client_cert),
+                                tls_client_key: ch(path, :tls_client_key),
+                                tls_cacert: ch(path, :tls_cacert)
+                                )
       end
     end
 
@@ -233,6 +243,13 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: conf.wait_duration + 1 + (conf.wait_duration / 16) # default connection inactivity (post-setup) timeout
         }
+        if !conf.tls_client_cert.nil?
+          options[:tls] = {
+            cert_chain_file: conf.tls_client_cert,
+            private_key_file: conf.tls_client_key,
+            verify_peer: false # TODO: use the tls_cacert in the cert_chain_file and verify
+          }
+        end
         connection = {
           conn: EventMachine::HttpRequest.new(conf.base_url, options)
         }

--- a/lib/consul/async/json_endpoint.rb
+++ b/lib/consul/async/json_endpoint.rb
@@ -187,7 +187,7 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 60 # default connection inactivity (post-setup) timeout
         }
-        if !conf.tls_client_cert.nil?
+        unless conf.tls_client_cert.nil?
           options[:tls] = {
             cert_chain_file: conf.tls_client_cert,
             private_key_file: conf.tls_client_key,

--- a/lib/consul/async/json_endpoint.rb
+++ b/lib/consul/async/json_endpoint.rb
@@ -9,7 +9,7 @@ module Consul
     class JSONConfiguration
       attr_reader :url, :retry_duration, :min_duration, :retry_on_non_diff,
                   :debug, :enable_gzip_compression, :request_method, :json_body,
-                  :headers
+                  :headers, :tls_client_cert, :tls_client_key, :tls_cacert
       def initialize(url:,
                      debug: { network: false },
                      retry_duration: 10,
@@ -18,7 +18,10 @@ module Consul
                      request_method: :get,
                      json_body: nil,
                      headers: {},
-                     enable_gzip_compression: true)
+                     enable_gzip_compression: true,
+                     tls_client_cert: nil,
+                     tls_client_key: nil,
+                     tls_cacert: nil)
         @url = url
         @debug = debug
         @enable_gzip_compression = enable_gzip_compression
@@ -28,6 +31,9 @@ module Consul
         @request_method = request_method
         @json_body = json_body
         @headers = headers
+        @tls_client_cert = tls_client_cert
+        @tls_client_key = tls_client_key
+        @tls_cacert = tls_cacert
       end
 
       def create(_url)
@@ -181,6 +187,13 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 60 # default connection inactivity (post-setup) timeout
         }
+        if !conf.tls_client_cert.nil?
+          options[:tls] = {
+            cert_chain_file: conf.tls_client_cert,
+            private_key_file: conf.tls_client_key,
+            verify_peer: false # TODO: use the tls_cacert in the cert_chain_file and verify
+          }
+        end
         connection = {
           conn: EventMachine::HttpRequest.new(conf.url, options)
         }

--- a/lib/consul/async/json_endpoint.rb
+++ b/lib/consul/async/json_endpoint.rb
@@ -9,7 +9,7 @@ module Consul
     class JSONConfiguration
       attr_reader :url, :retry_duration, :min_duration, :retry_on_non_diff,
                   :debug, :enable_gzip_compression, :request_method, :json_body,
-                  :headers, :tls_client_cert, :tls_client_key, :tls_cacert
+                  :headers, :tls_cert_chain, :tls_private_key, :tls_verify_peer
       def initialize(url:,
                      debug: { network: false },
                      retry_duration: 10,
@@ -19,9 +19,9 @@ module Consul
                      json_body: nil,
                      headers: {},
                      enable_gzip_compression: true,
-                     tls_client_cert: nil,
-                     tls_client_key: nil,
-                     tls_cacert: nil)
+                     tls_cert_chain: nil,
+                     tls_private_key: nil,
+                     tls_verify_peer: true)
         @url = url
         @debug = debug
         @enable_gzip_compression = enable_gzip_compression
@@ -31,9 +31,9 @@ module Consul
         @request_method = request_method
         @json_body = json_body
         @headers = headers
-        @tls_client_cert = tls_client_cert
-        @tls_client_key = tls_client_key
-        @tls_cacert = tls_cacert
+        @tls_cert_chain = tls_cert_chain
+        @tls_private_key = tls_private_key
+        @tls_verify_peer = tls_verify_peer
       end
 
       def create(_url)
@@ -187,11 +187,11 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 60 # default connection inactivity (post-setup) timeout
         }
-        unless conf.tls_client_cert.nil?
+        unless conf.tls_cert_chain.nil?
           options[:tls] = {
-            cert_chain_file: conf.tls_client_cert,
-            private_key_file: conf.tls_client_key,
-            verify_peer: false # TODO: use the tls_cacert in the cert_chain_file and verify
+            cert_chain_file: conf.tls_cert_chain,
+            private_key_file: conf.tls_private_key,
+            verify_peer: conf.tls_verify_peer
           }
         end
         connection = {

--- a/lib/consul/async/vault_endpoint.rb
+++ b/lib/consul/async/vault_endpoint.rb
@@ -232,7 +232,7 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 1 # default connection inactivity (post-setup) timeout
         }
-        if !conf.tls_client_cert.nil?
+        unless conf.tls_client_cert.nil?
           options[:tls] = {
             cert_chain_file: conf.tls_client_cert,
             private_key_file: conf.tls_client_key,

--- a/lib/consul/async/vault_endpoint.rb
+++ b/lib/consul/async/vault_endpoint.rb
@@ -10,7 +10,8 @@ module Consul
     # Configuration for Vault Endpoints
     class VaultConfiguration
       attr_reader :base_url, :token, :token_renew, :retry_duration, :min_duration, :wait_duration, :max_retry_duration, :retry_on_non_diff,
-                  :lease_duration_factor, :debug, :max_consecutive_errors_on_endpoint, :fail_fast_errors, :tls_client_cert, :tls_client_key, :tls_cacert
+                  :lease_duration_factor, :debug, :max_consecutive_errors_on_endpoint, :fail_fast_errors, :tls_cert_chain, :tls_private_key,
+                  :tls_verify_peer
 
       def initialize(base_url: 'http://localhost:8200',
                      debug: { network: false },
@@ -23,9 +24,9 @@ module Consul
                      paths: {},
                      max_consecutive_errors_on_endpoint: 10,
                      fail_fast_errors: false,
-                     tls_client_cert: nil,
-                     tls_client_key: nil,
-                     tls_cacert: nil)
+                     tls_cert_chain: nil,
+                     tls_private_key: nil,
+                     tls_verify_peer: true)
         @base_url = base_url
         @token_renew = token_renew
         @debug = debug
@@ -37,9 +38,9 @@ module Consul
         @token = token
         @max_consecutive_errors_on_endpoint = max_consecutive_errors_on_endpoint
         @fail_fast_errors = fail_fast_errors
-        @tls_client_cert = tls_client_cert
-        @tls_client_key = tls_client_key
-        @tls_cacert = tls_cacert
+        @tls_cert_chain = tls_cert_chain
+        @tls_private_key = tls_private_key
+        @tls_verify_peer = tls_verify_peer
       end
 
       def ch(path, symbol)
@@ -232,11 +233,11 @@ module Consul
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 1 # default connection inactivity (post-setup) timeout
         }
-        unless conf.tls_client_cert.nil?
+        unless conf.tls_cert_chain.nil?
           options[:tls] = {
-            cert_chain_file: conf.tls_client_cert,
-            private_key_file: conf.tls_client_key,
-            verify_peer: false # TODO: use the tls_cacert in the cert_chain_file and verify
+            cert_chain_file: conf.tls_cert_chain,
+            private_key_file: conf.tls_private_key,
+            verify_peer: conf.tls_verify_peer
           }
         end
         connection = EventMachine::HttpRequest.new(conf.base_url, options)


### PR DESCRIPTION
This uses the default consul and vault environment variables to determine if it should authenticate with client certificate and key.

I only tested it manually on a setup that uses TLS authentication.