### PR TITLE
[VAULT] Do not handle missing secret as a blocking exception

### DIFF
--- a/lib/consul/async/vault_endpoint.rb
+++ b/lib/consul/async/vault_endpoint.rb
@@ -245,7 +245,7 @@ module Consul
           http = connection.send(http_method.downcase, build_request) # Under the hood: c.send('get', {stuff}) === c.get({stuff})
           http.callback do
             http_result = VaultHttpResponse.new(http.dup.freeze, default_value)
-            if enforce_json_200 && http.response_header.status != 200
+            if enforce_json_200 && ![200, 404].include?(http.response_header.status)
               _handle_error(http_result) { connection = EventMachine::HttpRequest.new(conf.base_url, options) }
             else
               @consecutive_errors = 0


### PR DESCRIPTION
Return empty value when the secret is missing from Vault (404).
It will avoid raising when trying to read missing values.