### PR TITLE
Hide opts in logs by default

### DIFF
--- a/lib/consul/async/consul_template.rb
+++ b/lib/consul/async/consul_template.rb
@@ -31,7 +31,7 @@ module Consul
 
       def as_json(url, default_value, refresh_delay_secs: 10, **opts)
         conf = JSONConfiguration.new(url: url, min_duration: refresh_delay_secs, retry_on_non_diff: refresh_delay_secs, **opts)
-        endpoint_id = url + opts.to_json
+        endpoint_id = url + opts.hash.to_s
         @endp_manager.create_if_missing(url, {}, endpoint_id: endpoint_id) do
           if default_value.is_a?(Array)
             ConsulTemplateJSONArray.new(JSONEndpoint.new(conf, url, default_value))


### PR DESCRIPTION
When as_json style of resource, some logs include information with
passed options. This can include passwords.
Instead of displaying options, we simply need to have a stable id.
Hash.hash method is stable for the simple structions of options we have
(key/values are strings).

Change-Id: Ieee9682ba70070a29a3a39fbd6b16268d90ea3e1