### PR TITLE
Allow to stream log lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ It means that you can call consul-templaterb with `*.erb` arguments, the shell
 will then substitute all files and render it by removing the `.erb` extension as
 if the `--template my_file.ext.erb:myfile.ext` was used.
 
+If the program is run in an automatic context, it could be useful to stream
+logs instead of the default interactive log version which erase last log line.
+To configure this behavior, set the `STREAM_LOG` environment variable to any
+value.
+
 ### Generate multiple templates
 
 In the same way as consul-template, consul-templaterb supports multiple templates and executing

--- a/lib/consul/async/debug.rb
+++ b/lib/consul/async/debug.rb
@@ -26,7 +26,10 @@ module Consul
       end
 
       def self.print_info(msg)
+        return unless level > 1
+
         STDERR.print "[INFO] #{msg}" if level > 1
+        warn '' if ENV['LOG_STREAM']
       end
 
       def self.puts_debug(msg)
@@ -34,7 +37,10 @@ module Consul
       end
 
       def self.print_debug(msg)
-        STDERR.print "[DEBG] #{msg}" if level > 2
+        return unless level > 2
+
+        STDERR.print "[DEBG] #{msg}"
+        warn '' if ENV['LOG_STREAM']
       end
     end
   end


### PR DESCRIPTION
Currently, some logs are "printed" instead of output (i.e without a line
break).
It leads to have no log history when running under systemd or a
container system that capture log output.
This patch introduces a environment variable to tweak this subtle
behavior.

Change-Id: Ib3444d6dbf94dadcf80db529d00fb02ba5ee9f10