### PR TITLE
Validate ssl peers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,8 +6,9 @@ AllCops:
 Layout/LineLength:
   Max: 175
 
+# those metrics should be disabled
 Metrics/AbcSize:
-  Max: 90
+  Max: 92
 
 Metrics/BlockLength:
   Max: 188

--- a/lib/consul/async/consul_endpoint.rb
+++ b/lib/consul/async/consul_endpoint.rb
@@ -265,7 +265,8 @@ module Consul
       def fetch
         options = {
           connect_timeout: 5, # default connection setup timeout
-          inactivity_timeout: conf.wait_duration + 1 + (conf.wait_duration / 16) # default connection inactivity (post-setup) timeout
+          inactivity_timeout: conf.wait_duration + 1 + (conf.wait_duration / 16), # default connection inactivity (post-setup) timeout
+          tls: { verify_peer: conf.tls_verify_peer }
         }
         unless conf.tls_cert_chain.nil?
           options[:tls] = {

--- a/lib/consul/async/json_endpoint.rb
+++ b/lib/consul/async/json_endpoint.rb
@@ -184,6 +184,7 @@ module Consul
 
       def fetch
         options = {
+          tls: { verify_peer: conf.tls_verify_peer },
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 60 # default connection inactivity (post-setup) timeout
         }

--- a/lib/consul/async/vault_endpoint.rb
+++ b/lib/consul/async/vault_endpoint.rb
@@ -230,6 +230,7 @@ module Consul
 
       def fetch
         options = {
+          tls: { verify_peer: conf.tls_verify_peer },
           connect_timeout: 5, # default connection setup timeout
           inactivity_timeout: 1 # default connection inactivity (post-setup) timeout
         }


### PR DESCRIPTION
Before this patch, ssl peers where not validated unless custom
certificate were provided. This led to less strict security and annoying
warnings from em-http library. See https://github.com/igrigorik/em-http-request/issues/339.

Now we properly take tls_verify_peer option (defaults to true) in
consideration. This should increase security.

⚠ This is certainly a change for users who uses invalid certificate. However, the options `--skip-*-verify-tls` should help them to explicitely disable validation if necessary.