### PR TITLE
Correctly identify endpoints

### DIFF
--- a/lib/consul/async/consul_template.rb
+++ b/lib/consul/async/consul_template.rb
@@ -400,8 +400,9 @@ module Consul
                             agent: nil, endpoint_id: nil)
         endpoint_id ||= begin
                           fqdn = path.dup
+                          fqdn = "#{agent}#{fqdn}"
                           query_params.each_pair do |k, v|
-                            fqdn = "#{agent}#{fqdn}&#{k}=#{v}"
+                            fqdn += "&#{k}=#{v}"
                           end
                           fqdn
                         end


### PR DESCRIPTION
For enpdoints used without any query_params but with an agent, we used
to store incorrect endpoint.
To reproduce the bug here is a simple template:
```
datacenters(agent: "https://consul.preprod") + datacenters(agent:"https://consul.prod")
```

This template should list datacenters from both environment but actually
only list datacenters from preprod (twice) because the
agent is not taken into account in the endpoint id.

Change-Id: Ic67fec3f4085b7e680da21a30b693c08f8ee2894