### PR TITLE
Add restart param

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Metrics/AbcSize:
   Max: 92
 
 Metrics/BlockLength:
-  Max: 188
+  Max: 192
 
 Metrics/BlockNesting:
   Max: 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 1.31.3 (Dec 07 2022)
+
+IMPROVEMENTS:
+
+* Add restart mode
+
+
 ## 1.31.2 (Aug 04 2022)
 
 BUG FIX:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ USAGE: consul-templaterb [[options]]
     -M, --debug-memory-usage         Display messages when RAM grows
     -T, --trim-mode=trim_mode        ERB Trim mode to use (- by default)
     -R, --sig-reload=reload_signal   Signal to send to next --exec command on reload (NONE supported), default=HUP
+        --restart                    restart the --exec command on each configuration change(if your process do not handle hot-reload)    
     -W, --wait-signal=min_duration   Wait at least n seconds before each reload signal being sent to next --exec process
     -e, --exec=<command>             Execute the following command in as a subprocess when all templates are ready
     -d, --debug-network-usage        Debug the network usage

--- a/bin/consul-templaterb
+++ b/bin/consul-templaterb
@@ -94,6 +94,7 @@ consul_engine = Consul::Async::ConsulTemplateEngine.new
 @programs = {}
 cur_sig_reload = 'HUP'.freeze
 cur_sig_term = 'TERM'.freeze
+restart = false
 cur_min_duration_between_signals = 1
 
 optparse = OptionParser.new do |opts|
@@ -230,6 +231,11 @@ optparse = OptionParser.new do |opts|
     cur_sig_reload = compute_signal(sig, 'NONE')
   end
 
+  opts.on('--restart', 'restart the --exec command on each configuration change ' \
+                             '(if your process do not handle hot-reload)') do
+    restart = true
+  end
+
   opts.on('-W', '--wait-signal=min_duration', Float, 'Wait at least n seconds before each reload signal being sent to next --exec process') do |min_duration|
     raise "-wait-between-reload-signal=#{min_duration} must be greater than 0" unless min_duration.positive?
 
@@ -256,7 +262,7 @@ optparse = OptionParser.new do |opts|
             now = Time.now
             delay = sig_min_interval - (now - @programs[cmd].last_signal_sent)
             delay = 0 if delay.negative?
-            EventMachine.add_timer(delay) { process_to_reload.reload }
+            EventMachine.add_timer(delay) { restart ? process_to_reload.restart : process_to_reload.reload }
           end
           begin
             process_to_reload.process_status

--- a/lib/consul/async/process_handler.rb
+++ b/lib/consul/async/process_handler.rb
@@ -9,6 +9,14 @@ module Consul
     class ProcessHandler
       attr_reader :command, :sig_reload, :sig_term, :pid, :exit_status, :last_signal_sent, :reload_scheduled
       attr_writer :reload_scheduled
+
+      def restart
+        warn "Restart process with pid #{pid}"
+        kill
+        start
+        @reload_scheduled = false
+      end
+
       def initialize(command, sig_reload: 'HUP', sig_term: 'TERM')
         raise 'empty sig_term is not supported' unless sig_term
 

--- a/lib/consul/async/version.rb
+++ b/lib/consul/async/version.rb
@@ -1,5 +1,5 @@
 module Consul
   module Async
-    VERSION = '1.33.2'.freeze
+    VERSION = '1.33.3'.freeze
   end
 end


### PR DESCRIPTION
Some programs don't have support hot-reload on configuration change. This patch introduce a –-restart args to restart the program after each configuration change.