### PR TITLE
Use named parameters in ERB.new function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ samples/consul-ui/decorators.js
 /samples/hosts
 /samples/hosts_per_services
 /samples/prometheus_consul_coordinates
-/samples/ready
+/samples/consul-ui/ready
 /samples/render_template_from_kv
 /samples/consul_template
 /samples/metrics

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:3.2
 
 WORKDIR /usr/src/app
 COPY . .

--- a/lib/consul/async/consul_template.rb
+++ b/lib/consul/async/consul_template.rb
@@ -318,7 +318,7 @@ module Consul
           params: params,
           template_info: tpl_info
         }
-        result = ERB.new(tpl, nil, @trim_mode).result(binding)
+        result = ERB.new(tpl, trim_mode: @trim_mode).result(binding)
         raise "Result is not a string :='#{result}' for #{tpl_file_path}" unless result.is_a?(String)
 
         @context = old_value


### PR DESCRIPTION
Since Ruby v3 the meaning of 2nd and 3rd parameters to ERB.new changed as well as the way the arguments should be passed. It requires a named 2nd parameter now.

Also update Dockerfile ruby image version for local testing.

https://docs.ruby-lang.org/en/3.0/ERB.html

Closes #90 