### PR TITLE
Use instance FQDN when available

### DIFF
--- a/samples/consul-ui/decorators.js.erb
+++ b/samples/consul-ui/decorators.js.erb
@@ -39,7 +39,7 @@ function usefullLinksGenerator(instance, serviceName, node_meta_info) {
 /**
  * createNodeDisplayElement resolves and displays the node name.
  */
-function createNodeDisplayElement(nodeName, nodemeta) {
+function createNodeDisplayElement(nodeName, _nodemeta, _instanceFqdn) {
   return document.createTextNode(nodeName);
 }
 

--- a/samples/consul-ui/js/utils.js
+++ b/samples/consul-ui/js/utils.js
@@ -87,7 +87,7 @@ function serviceTitleGenerator(instance, serviceName, node_info) {
     }
 
     var nodemeta = (node_info != null) ? node_info.meta : null; 
-    instanceLink.appendChild(createNodeDisplayElement(instance.name, nodemeta));
+    instanceLink.appendChild(createNodeDisplayElement(instance.name, nodemeta, instance.fqdn, instance?.sMeta?.fqdn));
     instanceLink.appendChild(document.createTextNode(appendPort));
 
     const nodeInfo = document.createElement('a');

--- a/samples/consul-ui/js/utils.js
+++ b/samples/consul-ui/js/utils.js
@@ -87,7 +87,7 @@ function serviceTitleGenerator(instance, serviceName, node_info) {
     }
 
     var nodemeta = (node_info != null) ? node_info.meta : null; 
-    instanceLink.appendChild(createNodeDisplayElement(instance.name, nodemeta, instance.fqdn, instance?.sMeta?.fqdn));
+    instanceLink.appendChild(createNodeDisplayElement(instance.name, nodemeta, instance?.sMeta?.fqdn));
     instanceLink.appendChild(document.createTextNode(appendPort));
 
     const nodeInfo = document.createElement('a');


### PR DESCRIPTION
When the CNI is enabled, the FQDN should be the container's IP and not the host's FQDN.
Using instance.sMeta.fqdn when available ensures we use the proper FQDN in both cases.