### PR TITLE
Display UTC dates

### DIFF
--- a/lib/consul/async/version.rb
+++ b/lib/consul/async/version.rb
@@ -1,5 +1,5 @@
 module Consul
   module Async
-    VERSION = '1.33.3'.freeze
+    VERSION = '1.34.1'.freeze
   end
 end

--- a/samples/consul-ui/js/utils.js
+++ b/samples/consul-ui/js/utils.js
@@ -34,7 +34,7 @@ function padDateUnit(x) {
 }
 
 function formatDate(date) {
-    return padDateUnit(date.getMonth() + 1) + "/" + padDateUnit(date.getDate()) + " " + padDateUnit(date.getHours()) + ':' + padDateUnit(date.getMinutes()) + ':' + padDateUnit(date.getSeconds());
+    return padDateUnit(date.getUTCMonth() + 1) + "/" + padDateUnit(date.getUTCDate()) + " " + padDateUnit(date.getUTCHours()) + ':' + padDateUnit(date.getUTCMinutes()) + ':' + padDateUnit(date.getUTCSeconds()) + " UTC";
 }
 
 function indexOfTimelineEvent(e) {


### PR DESCRIPTION
This is totally opinionated, but UTC dates are sometimes preferred to remove ambiguities.

Here it will output:
```
02/17 15:21:10 UTC
```

Instead of
```
02/17 16:21:10
```

(I'm in UTC+1 TZ)