### PR TITLE
Add simple rspec tests to json_endpoint

### DIFF
--- a/lib/consul/async/json_endpoint.rb
+++ b/lib/consul/async/json_endpoint.rb
@@ -1,5 +1,6 @@
 require 'consul/async/utilities'
 require 'consul/async/stats'
+require 'consul/async/debug'
 require 'em-http'
 require 'json'
 

--- a/lib/consul/async/json_endpoint_spec.rb
+++ b/lib/consul/async/json_endpoint_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'spec_helper'
+require 'consul/async/json_endpoint'
+require 'webmock/rspec'
+
+RSpec.describe Consul::Async do
+  context 'default parameters' do
+    it 'request 200' do
+      mock_url = 'http://perfectly.working.url'
+      conf = Consul::Async::JSONConfiguration.new(url: mock_url)
+      default_value = '[]'
+
+      json_endpoint = nil
+      response_body = %w[a b]
+      stub_request(:get, mock_url)
+        .to_return(body: response_body.to_json, status: 200)
+      EM.run_block do
+        json_endpoint = Consul::Async::JSONEndpoint.new(conf, mock_url, default_value)
+      end
+      expect(json_endpoint.ready?).to eq(true)
+      expect(json_endpoint.last_result.data).to eq(response_body.to_json)
+    end
+
+    it 'request 500' do
+      mock_url = 'http://error.working.url'
+      conf = Consul::Async::JSONConfiguration.new(url: mock_url)
+      default_value = ''
+
+      json_endpoint = nil
+      stub_request(:get, mock_url)
+        .to_return(body: '', status: 500)
+      EM.run_block do
+        json_endpoint = Consul::Async::JSONEndpoint.new(conf, mock_url, default_value)
+      end
+      expect(json_endpoint.ready?).to_not eq(true)
+      expect(json_endpoint.last_result.retry_in).to be_positive
+    end
+
+    it 'on timeout' do
+      mock_url = 'http://not.working.url'
+      conf = Consul::Async::JSONConfiguration.new(url: mock_url)
+      default_value = ''
+
+      stub_request(:get, mock_url).to_timeout
+      json_endpoint = nil
+      EM.run_block do
+        json_endpoint = Consul::Async::JSONEndpoint.new(conf, mock_url, default_value, enforce_json_200: true)
+      end
+      expect(json_endpoint.ready?).to_not eq(true)
+      expect(json_endpoint.last_result.retry_in).to be_positive
+    end
+  end
+end


### PR DESCRIPTION
Add simple tests to json_endpont class.

Later I'm going to extend json_endpoint, these tests will help ensure that nothing is broken.
Please, let me know if you think that some other tests are worth to be added.